### PR TITLE
Slightly brightened colors of links for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ A simple web application that helps you **count your time** that you are **spend
 - [**luucashc**](https://github.com/luucashc)
 - [**mmikaeleriksson**](https://github.com/mmikaeleriksson)
 - [**Saurabh-Sangam**](https://github.com/SaurabhS78)
+- [**rydwhelchel**](https://github.com/rydwhelchel)

--- a/css/worktime.css
+++ b/css/worktime.css
@@ -175,16 +175,16 @@ body {
     background: #244751;
 }
 
-[data-theme="dark"] a:link {
-    color: #0000EE;
+[data-theme="dark"] .about-links:link {
+    color: #009EEE;
 }
 
-[data-theme="dark"] a:visited {
-    color: #551A8B;
+[data-theme="dark"] .about-links:visited {
+    color: #009EEE;
 }
 
-[data-theme="dark"] a:hover {
-    color:white;
+[data-theme="dark"] .about-links:hover {
+    color:#00BEEE;
 }
 
 [data-theme="dark"] .container-rect {

--- a/css/worktime.css
+++ b/css/worktime.css
@@ -175,6 +175,18 @@ body {
     background: #244751;
 }
 
+[data-theme="dark"] a:link {
+    color: #0000EE;
+}
+
+[data-theme="dark"] a:visited {
+    color: #551A8B;
+}
+
+[data-theme="dark"] a:hover {
+    color:white;
+}
+
 [data-theme="dark"] .container-rect {
     background: rgb(43, 43, 43,1);
 }

--- a/index.html
+++ b/index.html
@@ -169,13 +169,13 @@
             </a>
 
             <h3>Libraries</h3>
-            <li><a href="https://getbootstrap.com/" target="_blank">Bootstrap</a></li>
-            <li><a href="https://fontawesome.com/" target="_blank">Font Awesome</a></li>
+            <li><a class="about-links" href="https://getbootstrap.com/" target="_blank">Bootstrap</a></li>
+            <li><a class="about-links" href="https://fontawesome.com/" target="_blank">Font Awesome</a></li>
             <hr>
 
             <h3>Submodules</h3>
-            <li><a href="https://github.com/objectivehtml/FlipClock/" target="_blank">FlipClock</a></li>
-            <li><a href="https://github.com/weareoutman/clockpicker/" target="_blank">clockpicker</a></li>
+            <li><a class="about-links" href="https://github.com/objectivehtml/FlipClock/" target="_blank">FlipClock</a></li>
+            <li><a class="about-links" href="https://github.com/weareoutman/clockpicker/" target="_blank">clockpicker</a></li>
             <hr>
 
             <div id="debugSwitch">


### PR DESCRIPTION
This pull request resolves issue #53 

Description: Slightly brightened colors of links in the About section when the user is in dark mode.


### Checklist

I have:
* [x] Followed the library usage listed in [CONTRIBUTING.md/Library usage](../CONTRIBUTING.md#library-usage)
* [x] Followed indentation steps listed in [CONTRIBUTING.md/Indentation](../CONTRIBUTING.md#indentation)
* [x] Followed pull request steps listed in [CONTRIBUTING.md/Pull request](../CONTRIBUTING.md#pull-request)
* [x] Followed the code standard in the project
