### PR TITLE
fix: add padding to about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
                 <div id="githubBtnLogo"></div>
             </a>
 
-            <h3>Libraries</h3>
+            <h3 style="margin-top: 10px;">Libraries</h3>
             <li><a href="https://getbootstrap.com/" target="_blank">Bootstrap</a></li>
             <li><a href="https://fontawesome.com/" target="_blank">Font Awesome</a></li>
             <hr>


### PR DESCRIPTION
This pull request resolves issue #issue number 52

https://github.com/mmikaeleriksson/workTime/issues/52

Description: Add paddomg to about page
description of changes: adding margin to h2

### Checklist

I have:
* [x] Followed the library usage listed in [CONTRIBUTING.md/Library usage](../CONTRIBUTING.md#library-usage)
* [x] Followed indentation steps listed in [CONTRIBUTING.md/Indentation](../CONTRIBUTING.md#indentation)
* [x] Followed pull request steps listed in [CONTRIBUTING.md/Pull request](../CONTRIBUTING.md#pull-request)
* [x] Followed the code standard in the project
